### PR TITLE
PDAL_DRIVER_PATH must be set to bin directory where plugins are installed

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - geos.patch
 
 build:
-  number: 4
+  number: 5
   features:
     - vc14  # [win]
   skip: True  # [win and py!=36]

--- a/recipe/scripts/activate.bat
+++ b/recipe/scripts/activate.bat
@@ -7,7 +7,7 @@
 
 @REM Support plugins if the plugin directory exists
 @REM i.e if it has been manually created by the user
-@set "PDAL_DRIVER_PATH=%CONDA_PREFIX%\Library\lib"
+@set "PDAL_DRIVER_PATH=%CONDA_PREFIX%\Library\bin"
 @if not exist %PDAL_DRIVER_PATH% (
      set "PDAL_DRIVER_PATH="
 )


### PR DESCRIPTION
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.

Closes #11 