### PR TITLE
cb3 syntax, use more global pins

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,10 +9,10 @@ environment:
     secure: ipv/06DzgA7pzz2CIAtbPxZSsphDtF+JFyoWRnXkn3O8j7oRe3rzqj3LOoq2DZp4
 
   matrix:
-    - CONFIG: win_python3.5vc14
+    - CONFIG: win_cxx_compilervs2015python3.5vc14
       CONDA_INSTALL_LOCN: C:\Miniconda36-x64
 
-    - CONFIG: win_python3.6vc14
+    - CONFIG: win_cxx_compilervs2015python3.6vc14
       CONDA_INSTALL_LOCN: C:\Miniconda36-x64
 
 

--- a/.ci_support/linux_python2.7.yaml
+++ b/.ci_support/linux_python2.7.yaml
@@ -1,5 +1,7 @@
 curl:
 - '7.59'
+cxx_compiler:
+- toolchain_cxx
 geos:
 - 3.6.2
 libgdal:

--- a/.ci_support/linux_python3.5.yaml
+++ b/.ci_support/linux_python3.5.yaml
@@ -1,5 +1,7 @@
 curl:
 - '7.59'
+cxx_compiler:
+- toolchain_cxx
 geos:
 - 3.6.2
 libgdal:

--- a/.ci_support/linux_python3.6.yaml
+++ b/.ci_support/linux_python3.6.yaml
@@ -1,5 +1,7 @@
 curl:
 - '7.59'
+cxx_compiler:
+- toolchain_cxx
 geos:
 - 3.6.2
 libgdal:

--- a/.ci_support/osx_python2.7.yaml
+++ b/.ci_support/osx_python2.7.yaml
@@ -2,6 +2,8 @@ MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 curl:
 - '7.59'
+cxx_compiler:
+- toolchain_cxx
 geos:
 - 3.6.2
 libgdal:

--- a/.ci_support/osx_python3.5.yaml
+++ b/.ci_support/osx_python3.5.yaml
@@ -2,6 +2,8 @@ MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 curl:
 - '7.59'
+cxx_compiler:
+- toolchain_cxx
 geos:
 - 3.6.2
 libgdal:

--- a/.ci_support/osx_python3.6.yaml
+++ b/.ci_support/osx_python3.6.yaml
@@ -2,6 +2,8 @@ MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 curl:
 - '7.59'
+cxx_compiler:
+- toolchain_cxx
 geos:
 - 3.6.2
 libgdal:

--- a/.ci_support/win_cxx_compilervs2015python3.5vc14.yaml
+++ b/.ci_support/win_cxx_compilervs2015python3.5vc14.yaml
@@ -1,5 +1,7 @@
 curl:
 - '7.59'
+cxx_compiler:
+- vs2015
 geos:
 - 3.6.2
 libgdal:
@@ -28,8 +30,5 @@ sqlite:
 - '3'
 vc:
 - '14'
-zip_keys:
-- - python
-  - vc
 zlib:
 - '1.2'

--- a/.ci_support/win_cxx_compilervs2015python3.6vc14.yaml
+++ b/.ci_support/win_cxx_compilervs2015python3.6vc14.yaml
@@ -1,5 +1,7 @@
 curl:
 - '7.59'
+cxx_compiler:
+- vs2015
 geos:
 - 3.6.2
 libgdal:
@@ -28,8 +30,5 @@ sqlite:
 - '3'
 vc:
 - '14'
-zip_keys:
-- - python
-  - vc
 zlib:
 - '1.2'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,24 +14,22 @@ source:
     - geos.patch
 
 build:
-  number: 9
-  features:
-    - vc14  # [win]
-  skip: True  # [win and py<35]
+  number: 10
+  skip: True  # [win and vc<14]
 
 requirements:
   build:
+    - {{ compiler('cxx') }}
     - cmake
-    - toolchain
+  host:
     - python
-    - vc 14  # [win]
-    - numpy 1.11.*
-    - libgdal 2.2.*
-    - geos 3.6.*
+    - numpy
+    - libgdal
+    - geos
     - postgresql 10.3.*
     - jsoncpp
     - eigen 3.3.*
-    - sqlite 3.20.*
+    - sqlite
     - laz-perf 1.1.*
     - nitro <2.8
     - hexer 1.4.*
@@ -40,19 +38,13 @@ requirements:
     - zlib
   run:
     - python
-    - numpy >=1.11
-    - libgdal 2.2.*
-    - geos 3.6.*
-    - postgresql 10.3.*
-    - jsoncpp
-    - sqlite 3.20.*
-    - laz-perf 1.1.*
-    - nitro <2.8
-    - hexer 1.4.*
-    - laszip 3.2.*
-    - vc 14  # [win]
-    - curl
-    - zlib
+    - {{ pin_compatible('numpy') }}
+    - {{ pin_compatible('jsoncpp', max_pin='x.x.x') }}
+    - {{ pin_compatible('postgresql', max_pin='x.x') }}
+    - {{ pin_compatible('laz-perf', max_pin='x.x') }}
+    - {{ pin_compatible('nitro', max_pin='x.x') }}
+    - {{ pin_compatible('hexer', max_pin='x.x') }}
+    - {{ pin_compatible('laszip', max_pin='x.x') }}
 
 test:
   commands:


### PR DESCRIPTION
Modernize the `meta.yaml` a little bit, including pulling in more pins automatically. Only real effect on the output should be that it builds with an older `numpy` when possible.