### PR TITLE
Fix stupidity

### DIFF
--- a/.ci_support/win_cxx_compilervs2015python3.5vc14.yaml
+++ b/.ci_support/win_cxx_compilervs2015python3.5vc14.yaml
@@ -30,5 +30,9 @@ sqlite:
 - '3'
 vc:
 - '14'
+zip_keys:
+- - python
+  - vc
+  - cxx_compiler
 zlib:
 - '1.2'

--- a/.ci_support/win_cxx_compilervs2015python3.6vc14.yaml
+++ b/.ci_support/win_cxx_compilervs2015python3.6vc14.yaml
@@ -30,5 +30,9 @@ sqlite:
 - '3'
 vc:
 - '14'
+zip_keys:
+- - python
+  - vc
+  - cxx_compiler
 zlib:
 - '1.2'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - geos.patch
 
 build:
-  number: 10
+  number: 11
   skip: True  # [win and vc<14]
 
 requirements:
@@ -45,6 +45,10 @@ requirements:
     - {{ pin_compatible('nitro', max_pin='x.x') }}
     - {{ pin_compatible('hexer', max_pin='x.x') }}
     - {{ pin_compatible('laszip', max_pin='x.x') }}
+    - libgdal
+    - geos
+    - curl
+    - zlib
 
 test:
   commands:


### PR DESCRIPTION
I was dumb in #26 – `pin_run_as_build` handles the versioning when you specify a `run` dep, but not the `run` dep itself. This is needed to specify the dependencies properly.

cc @bgruening 