### PR TITLE
Revert dependencies back to 1.7.2 configuration

### DIFF
--- a/.ci_support/linux_python2.7.yaml
+++ b/.ci_support/linux_python2.7.yaml
@@ -9,7 +9,7 @@ cxx_compiler:
 docker_image:
 - condaforge/linux-anvil
 gdal:
-- 2.3.2
+- '2.3'
 geos:
 - 3.6.2
 hdf5:

--- a/.ci_support/linux_python2.7.yaml
+++ b/.ci_support/linux_python2.7.yaml
@@ -16,8 +16,8 @@ hdf5:
 - 1.10.3
 jsoncpp:
 - 1.8.1
-libkml:
-- '1.3'
+libgdal:
+- '2.3'
 numpy:
 - '1.9'
 pin_run_as_build:
@@ -31,7 +31,7 @@ pin_run_as_build:
     max_pin: x.x.x
   jsoncpp:
     max_pin: x.x.x
-  libkml:
+  libgdal:
     max_pin: x.x
   python:
     min_pin: x.x

--- a/.ci_support/linux_python2.7.yaml
+++ b/.ci_support/linux_python2.7.yaml
@@ -8,6 +8,8 @@ cxx_compiler:
 - toolchain_cxx
 docker_image:
 - condaforge/linux-anvil
+gdal:
+- 2.3.2
 geos:
 - 3.6.2
 hdf5:
@@ -21,6 +23,8 @@ numpy:
 pin_run_as_build:
   curl:
     max_pin: x
+  gdal:
+    max_pin: x.x
   geos:
     max_pin: x.x.x
   hdf5:

--- a/.ci_support/linux_python2.7.yaml
+++ b/.ci_support/linux_python2.7.yaml
@@ -18,6 +18,8 @@ jsoncpp:
 - 1.8.1
 libgdal:
 - '2.3'
+libkml:
+- '1.3'
 numpy:
 - '1.9'
 pin_run_as_build:
@@ -32,6 +34,8 @@ pin_run_as_build:
   jsoncpp:
     max_pin: x.x.x
   libgdal:
+    max_pin: x.x
+  libkml:
     max_pin: x.x
   python:
     min_pin: x.x

--- a/.ci_support/linux_python3.6.yaml
+++ b/.ci_support/linux_python3.6.yaml
@@ -9,7 +9,7 @@ cxx_compiler:
 docker_image:
 - condaforge/linux-anvil
 gdal:
-- 2.3.2
+- '2.3'
 geos:
 - 3.6.2
 hdf5:

--- a/.ci_support/linux_python3.6.yaml
+++ b/.ci_support/linux_python3.6.yaml
@@ -16,8 +16,8 @@ hdf5:
 - 1.10.3
 jsoncpp:
 - 1.8.1
-libkml:
-- '1.3'
+libgdal:
+- '2.3'
 numpy:
 - '1.9'
 pin_run_as_build:
@@ -31,7 +31,7 @@ pin_run_as_build:
     max_pin: x.x.x
   jsoncpp:
     max_pin: x.x.x
-  libkml:
+  libgdal:
     max_pin: x.x
   python:
     min_pin: x.x

--- a/.ci_support/linux_python3.6.yaml
+++ b/.ci_support/linux_python3.6.yaml
@@ -8,6 +8,8 @@ cxx_compiler:
 - toolchain_cxx
 docker_image:
 - condaforge/linux-anvil
+gdal:
+- 2.3.2
 geos:
 - 3.6.2
 hdf5:
@@ -21,6 +23,8 @@ numpy:
 pin_run_as_build:
   curl:
     max_pin: x
+  gdal:
+    max_pin: x.x
   geos:
     max_pin: x.x.x
   hdf5:

--- a/.ci_support/linux_python3.6.yaml
+++ b/.ci_support/linux_python3.6.yaml
@@ -18,6 +18,8 @@ jsoncpp:
 - 1.8.1
 libgdal:
 - '2.3'
+libkml:
+- '1.3'
 numpy:
 - '1.9'
 pin_run_as_build:
@@ -32,6 +34,8 @@ pin_run_as_build:
   jsoncpp:
     max_pin: x.x.x
   libgdal:
+    max_pin: x.x
+  libkml:
     max_pin: x.x
   python:
     min_pin: x.x

--- a/.ci_support/osx_python2.7.yaml
+++ b/.ci_support/osx_python2.7.yaml
@@ -16,8 +16,8 @@ hdf5:
 - 1.10.3
 jsoncpp:
 - 1.8.1
-libkml:
-- '1.3'
+libgdal:
+- '2.3'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
@@ -35,7 +35,7 @@ pin_run_as_build:
     max_pin: x.x.x
   jsoncpp:
     max_pin: x.x.x
-  libkml:
+  libgdal:
     max_pin: x.x
   python:
     min_pin: x.x

--- a/.ci_support/osx_python2.7.yaml
+++ b/.ci_support/osx_python2.7.yaml
@@ -9,7 +9,7 @@ curl:
 cxx_compiler:
 - toolchain_cxx
 gdal:
-- 2.3.2
+- '2.3'
 geos:
 - 3.6.2
 hdf5:

--- a/.ci_support/osx_python2.7.yaml
+++ b/.ci_support/osx_python2.7.yaml
@@ -18,6 +18,8 @@ jsoncpp:
 - 1.8.1
 libgdal:
 - '2.3'
+libkml:
+- '1.3'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
@@ -36,6 +38,8 @@ pin_run_as_build:
   jsoncpp:
     max_pin: x.x.x
   libgdal:
+    max_pin: x.x
+  libkml:
     max_pin: x.x
   python:
     min_pin: x.x

--- a/.ci_support/osx_python2.7.yaml
+++ b/.ci_support/osx_python2.7.yaml
@@ -8,6 +8,8 @@ curl:
 - '7.59'
 cxx_compiler:
 - toolchain_cxx
+gdal:
+- 2.3.2
 geos:
 - 3.6.2
 hdf5:
@@ -25,6 +27,8 @@ numpy:
 pin_run_as_build:
   curl:
     max_pin: x
+  gdal:
+    max_pin: x.x
   geos:
     max_pin: x.x.x
   hdf5:

--- a/.ci_support/osx_python3.6.yaml
+++ b/.ci_support/osx_python3.6.yaml
@@ -16,8 +16,8 @@ hdf5:
 - 1.10.3
 jsoncpp:
 - 1.8.1
-libkml:
-- '1.3'
+libgdal:
+- '2.3'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
@@ -35,7 +35,7 @@ pin_run_as_build:
     max_pin: x.x.x
   jsoncpp:
     max_pin: x.x.x
-  libkml:
+  libgdal:
     max_pin: x.x
   python:
     min_pin: x.x

--- a/.ci_support/osx_python3.6.yaml
+++ b/.ci_support/osx_python3.6.yaml
@@ -9,7 +9,7 @@ curl:
 cxx_compiler:
 - toolchain_cxx
 gdal:
-- 2.3.2
+- '2.3'
 geos:
 - 3.6.2
 hdf5:

--- a/.ci_support/osx_python3.6.yaml
+++ b/.ci_support/osx_python3.6.yaml
@@ -18,6 +18,8 @@ jsoncpp:
 - 1.8.1
 libgdal:
 - '2.3'
+libkml:
+- '1.3'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
@@ -36,6 +38,8 @@ pin_run_as_build:
   jsoncpp:
     max_pin: x.x.x
   libgdal:
+    max_pin: x.x
+  libkml:
     max_pin: x.x
   python:
     min_pin: x.x

--- a/.ci_support/osx_python3.6.yaml
+++ b/.ci_support/osx_python3.6.yaml
@@ -8,6 +8,8 @@ curl:
 - '7.59'
 cxx_compiler:
 - toolchain_cxx
+gdal:
+- 2.3.2
 geos:
 - 3.6.2
 hdf5:
@@ -25,6 +27,8 @@ numpy:
 pin_run_as_build:
   curl:
     max_pin: x
+  gdal:
+    max_pin: x.x
   geos:
     max_pin: x.x.x
   hdf5:

--- a/.ci_support/win_cxx_compilervs2015python3.6vc14.yaml
+++ b/.ci_support/win_cxx_compilervs2015python3.6vc14.yaml
@@ -14,8 +14,8 @@ hdf5:
 - 1.10.3
 jsoncpp:
 - 1.8.1
-libkml:
-- '1.3'
+libgdal:
+- '2.3'
 numpy:
 - '1.11'
 pin_run_as_build:
@@ -29,7 +29,7 @@ pin_run_as_build:
     max_pin: x.x.x
   jsoncpp:
     max_pin: x.x.x
-  libkml:
+  libgdal:
     max_pin: x.x
   python:
     min_pin: x.x

--- a/.ci_support/win_cxx_compilervs2015python3.6vc14.yaml
+++ b/.ci_support/win_cxx_compilervs2015python3.6vc14.yaml
@@ -6,6 +6,8 @@ curl:
 - '7.59'
 cxx_compiler:
 - vs2015
+gdal:
+- 2.3.2
 geos:
 - 3.6.2
 hdf5:
@@ -19,6 +21,8 @@ numpy:
 pin_run_as_build:
   curl:
     max_pin: x
+  gdal:
+    max_pin: x.x
   geos:
     max_pin: x.x.x
   hdf5:

--- a/.ci_support/win_cxx_compilervs2015python3.6vc14.yaml
+++ b/.ci_support/win_cxx_compilervs2015python3.6vc14.yaml
@@ -16,6 +16,8 @@ jsoncpp:
 - 1.8.1
 libgdal:
 - '2.3'
+libkml:
+- '1.3'
 numpy:
 - '1.11'
 pin_run_as_build:
@@ -30,6 +32,8 @@ pin_run_as_build:
   jsoncpp:
     max_pin: x.x.x
   libgdal:
+    max_pin: x.x
+  libkml:
     max_pin: x.x
   python:
     min_pin: x.x

--- a/.ci_support/win_cxx_compilervs2015python3.6vc14.yaml
+++ b/.ci_support/win_cxx_compilervs2015python3.6vc14.yaml
@@ -7,7 +7,7 @@ curl:
 cxx_compiler:
 - vs2015
 gdal:
-- 2.3.2
+- '2.3'
 geos:
 - 3.6.2
 hdf5:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - pcl.patch
 
 build:
-  number: 2
+  number: 3
   skip: True  # [win and vc<14]
 
 requirements:
@@ -57,7 +57,7 @@ requirements:
     - {{ pin_compatible('pcl', max_pin='x.x') }}
     - {{ pin_compatible('hdf5', max_pin='x.x.x') }}
     - {{ pin_compatible('geos', max_pin='x.x') }}
-    - {{ pin_compatible('libgdal', max_pin='x.x') }}
+    - {{ pin_compatible('libgdal', lower_bound='2.3', upper_bound='2.4')  }}
     - curl
     - zlib
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - pcl.patch
 
 build:
-  number: 3
+  number: 4
   skip: True  # [win and vc<14]
 
 requirements:
@@ -57,7 +57,7 @@ requirements:
     - {{ pin_compatible('pcl', max_pin='x.x') }}
     - {{ pin_compatible('hdf5', max_pin='x.x.x') }}
     - {{ pin_compatible('geos', max_pin='x.x') }}
-    - {{ pin_compatible('libgdal', lower_bound='2.3', upper_bound='2.4')  }}
+    - {{ pin_compatible('libgdal', max_pin='x.x') }}
     - curl
     - zlib
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,7 @@ requirements:
     - geos
     - postgresql 10.3.*
     - jsoncpp
+    - libkml
     - eigen 3.3.*
     - sqlite
     - laz-perf 1.2.*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,9 +25,10 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake
   host:
+    - libgdal  {{ gdal }}
     - python
     - numpy
-    - libgdal=2.3.*
+    - libgdal 2.3.*
     - geos
     - geotiff
     - postgresql 10.3.*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - pcl.patch
 
 build:
-  number: 4
+  number: 5
   skip: True  # [win and vc<14]
 
 requirements:
@@ -28,12 +28,10 @@ requirements:
     - libgdal  {{ gdal }}
     - python
     - numpy
-    - libgdal 2.3.*
+    - libgdal
     - geos
-    - geotiff
     - postgresql 10.3.*
     - jsoncpp
-    - libkml
     - eigen 3.3.*
     - sqlite
     - laz-perf 1.2.*
@@ -57,8 +55,8 @@ requirements:
     - {{ pin_compatible('laszip', max_pin='x.x') }}
     - {{ pin_compatible('pcl', max_pin='x.x') }}
     - {{ pin_compatible('hdf5', max_pin='x.x.x') }}
-    - {{ pin_compatible('geos', max_pin='x.x') }}
-    - {{ pin_compatible('libgdal', max_pin='x.x') }}
+    - libgdal {{ gdal }}
+    - geos
     - curl
     - zlib
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - pcl.patch
 
 build:
-  number: 1
+  number: 2
   skip: True  # [win and vc<14]
 
 requirements:
@@ -27,7 +27,7 @@ requirements:
   host:
     - python
     - numpy
-    - gdal=2.3.2
+    - libgdal=2.3.*
     - geos
     - geotiff
     - postgresql 10.3.*
@@ -56,8 +56,8 @@ requirements:
     - {{ pin_compatible('laszip', max_pin='x.x') }}
     - {{ pin_compatible('pcl', max_pin='x.x') }}
     - {{ pin_compatible('hdf5', max_pin='x.x.x') }}
-    - {{ pin_compatible('geos', max_pin='x.x.x') }}
-    - {{ pin_compatible('gdal', max_pin='x.x.x') }}
+    - {{ pin_compatible('geos', max_pin='x.x') }}
+    - {{ pin_compatible('libgdal', max_pin='x.x') }}
     - curl
     - zlib
 


### PR DESCRIPTION
* MNT: Re-rendered with conda-smithy 3.1.12 and pinning 2018.11.3

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
