### PR TITLE
Manual gdal dependencies

### DIFF
--- a/.ci_support/linux_python2.7.yaml
+++ b/.ci_support/linux_python2.7.yaml
@@ -15,7 +15,7 @@ hdf5:
 jsoncpp:
 - 1.8.1
 libgdal:
-- '2.2'
+- '2.3'
 numpy:
 - '1.9'
 pin_run_as_build:

--- a/.ci_support/linux_python2.7.yaml
+++ b/.ci_support/linux_python2.7.yaml
@@ -8,6 +8,8 @@ cxx_compiler:
 - toolchain_cxx
 docker_image:
 - condaforge/linux-anvil
+gdal:
+- 2.3.2
 geos:
 - 3.6.2
 hdf5:
@@ -21,6 +23,8 @@ numpy:
 pin_run_as_build:
   curl:
     max_pin: x
+  gdal:
+    max_pin: x.x
   geos:
     max_pin: x.x.x
   hdf5:

--- a/.ci_support/linux_python3.6.yaml
+++ b/.ci_support/linux_python3.6.yaml
@@ -15,7 +15,7 @@ hdf5:
 jsoncpp:
 - 1.8.1
 libgdal:
-- '2.2'
+- '2.3'
 numpy:
 - '1.9'
 pin_run_as_build:

--- a/.ci_support/linux_python3.6.yaml
+++ b/.ci_support/linux_python3.6.yaml
@@ -8,6 +8,8 @@ cxx_compiler:
 - toolchain_cxx
 docker_image:
 - condaforge/linux-anvil
+gdal:
+- 2.3.2
 geos:
 - 3.6.2
 hdf5:
@@ -21,6 +23,8 @@ numpy:
 pin_run_as_build:
   curl:
     max_pin: x
+  gdal:
+    max_pin: x.x
   geos:
     max_pin: x.x.x
   hdf5:

--- a/.ci_support/osx_python2.7.yaml
+++ b/.ci_support/osx_python2.7.yaml
@@ -15,7 +15,7 @@ hdf5:
 jsoncpp:
 - 1.8.1
 libgdal:
-- '2.2'
+- '2.3'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/.ci_support/osx_python2.7.yaml
+++ b/.ci_support/osx_python2.7.yaml
@@ -8,6 +8,8 @@ curl:
 - '7.59'
 cxx_compiler:
 - toolchain_cxx
+gdal:
+- 2.3.2
 geos:
 - 3.6.2
 hdf5:
@@ -25,6 +27,8 @@ numpy:
 pin_run_as_build:
   curl:
     max_pin: x
+  gdal:
+    max_pin: x.x
   geos:
     max_pin: x.x.x
   hdf5:

--- a/.ci_support/osx_python3.6.yaml
+++ b/.ci_support/osx_python3.6.yaml
@@ -15,7 +15,7 @@ hdf5:
 jsoncpp:
 - 1.8.1
 libgdal:
-- '2.2'
+- '2.3'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/.ci_support/osx_python3.6.yaml
+++ b/.ci_support/osx_python3.6.yaml
@@ -8,6 +8,8 @@ curl:
 - '7.59'
 cxx_compiler:
 - toolchain_cxx
+gdal:
+- 2.3.2
 geos:
 - 3.6.2
 hdf5:
@@ -25,6 +27,8 @@ numpy:
 pin_run_as_build:
   curl:
     max_pin: x
+  gdal:
+    max_pin: x.x
   geos:
     max_pin: x.x.x
   hdf5:

--- a/.ci_support/win_cxx_compilervs2015python3.6vc14.yaml
+++ b/.ci_support/win_cxx_compilervs2015python3.6vc14.yaml
@@ -6,6 +6,8 @@ curl:
 - '7.59'
 cxx_compiler:
 - vs2015
+gdal:
+- 2.3.2
 geos:
 - 3.6.2
 hdf5:
@@ -19,6 +21,8 @@ numpy:
 pin_run_as_build:
   curl:
     max_pin: x
+  gdal:
+    max_pin: x.x
   geos:
     max_pin: x.x.x
   hdf5:

--- a/.ci_support/win_cxx_compilervs2015python3.6vc14.yaml
+++ b/.ci_support/win_cxx_compilervs2015python3.6vc14.yaml
@@ -13,7 +13,7 @@ hdf5:
 jsoncpp:
 - 1.8.1
 libgdal:
-- '2.2'
+- '2.3'
 numpy:
 - '1.11'
 pin_run_as_build:


### PR DESCRIPTION
Smithy does not appear to be working. Try to manually set gdal dependencies. 

Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
