### PR TITLE
jsoncpp should not need to be pinned at the x.x.x level

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - pcl.patch
 
 build:
-  number: 5
+  number: 6
   skip: True  # [win and vc<14]
 
 requirements:
@@ -47,7 +47,7 @@ requirements:
   run:
     - python
     - {{ pin_compatible('numpy') }}
-    - {{ pin_compatible('jsoncpp', max_pin='x.x.x') }}
+    - {{ pin_compatible('jsoncpp', max_pin='x.x') }}
     - {{ pin_compatible('postgresql', max_pin='x.x') }}
     - {{ pin_compatible('laz-perf', max_pin='x.x') }}
     - {{ pin_compatible('geotiff', max_pin='x.x') }}


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
@conda-forge-admin please rerender

<!--
Please add any other relevant info below:
-->
