### PR TITLE
No longer need to install hexer

### DIFF
--- a/.ci_support/linux_python2.7.yaml
+++ b/.ci_support/linux_python2.7.yaml
@@ -9,13 +9,13 @@ cxx_compiler:
 docker_image:
 - condaforge/linux-anvil
 gdal:
-- '2.3'
+- 2.3.*
 geos:
-- 3.6.2
+- 3.7.0
 hdf5:
-- 1.10.3
+- 1.10.4
 jsoncpp:
-- 1.8.1
+- 1.8.4
 libkml:
 - '1.3'
 numpy:
@@ -26,8 +26,6 @@ pin_run_as_build:
   gdal:
     max_pin: x.x
   geos:
-    max_pin: x.x.x
-  hdf5:
     max_pin: x.x.x
   jsoncpp:
     max_pin: x.x.x

--- a/.ci_support/linux_python3.6.yaml
+++ b/.ci_support/linux_python3.6.yaml
@@ -9,13 +9,13 @@ cxx_compiler:
 docker_image:
 - condaforge/linux-anvil
 gdal:
-- '2.3'
+- 2.3.*
 geos:
-- 3.6.2
+- 3.7.0
 hdf5:
-- 1.10.3
+- 1.10.4
 jsoncpp:
-- 1.8.1
+- 1.8.4
 libkml:
 - '1.3'
 numpy:
@@ -26,8 +26,6 @@ pin_run_as_build:
   gdal:
     max_pin: x.x
   geos:
-    max_pin: x.x.x
-  hdf5:
     max_pin: x.x.x
   jsoncpp:
     max_pin: x.x.x

--- a/.ci_support/osx_python2.7.yaml
+++ b/.ci_support/osx_python2.7.yaml
@@ -9,13 +9,13 @@ curl:
 cxx_compiler:
 - toolchain_cxx
 gdal:
-- '2.3'
+- 2.3.*
 geos:
-- 3.6.2
+- 3.7.0
 hdf5:
-- 1.10.3
+- 1.10.4
 jsoncpp:
-- 1.8.1
+- 1.8.4
 libkml:
 - '1.3'
 macos_machine:
@@ -30,8 +30,6 @@ pin_run_as_build:
   gdal:
     max_pin: x.x
   geos:
-    max_pin: x.x.x
-  hdf5:
     max_pin: x.x.x
   jsoncpp:
     max_pin: x.x.x

--- a/.ci_support/osx_python3.6.yaml
+++ b/.ci_support/osx_python3.6.yaml
@@ -9,13 +9,13 @@ curl:
 cxx_compiler:
 - toolchain_cxx
 gdal:
-- '2.3'
+- 2.3.*
 geos:
-- 3.6.2
+- 3.7.0
 hdf5:
-- 1.10.3
+- 1.10.4
 jsoncpp:
-- 1.8.1
+- 1.8.4
 libkml:
 - '1.3'
 macos_machine:
@@ -30,8 +30,6 @@ pin_run_as_build:
   gdal:
     max_pin: x.x
   geos:
-    max_pin: x.x.x
-  hdf5:
     max_pin: x.x.x
   jsoncpp:
     max_pin: x.x.x

--- a/.ci_support/win_cxx_compilervs2015python3.6vc14.yaml
+++ b/.ci_support/win_cxx_compilervs2015python3.6vc14.yaml
@@ -7,13 +7,13 @@ curl:
 cxx_compiler:
 - vs2015
 gdal:
-- '2.3'
+- 2.3.*
 geos:
-- 3.6.2
+- 3.7.0
 hdf5:
-- 1.10.3
+- 1.10.4
 jsoncpp:
-- 1.8.1
+- 1.8.4
 libkml:
 - '1.3'
 numpy:
@@ -24,8 +24,6 @@ pin_run_as_build:
   gdal:
     max_pin: x.x
   geos:
-    max_pin: x.x.x
-  hdf5:
     max_pin: x.x.x
   jsoncpp:
     max_pin: x.x.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - pcl.patch
 
 build:
-  number: 5
+  number: 6
   skip: True  # [win and vc<14]
 
 requirements:
@@ -38,7 +38,6 @@ requirements:
     - sqlite
     - laz-perf 1.2.*
     - nitro <2.8
-    - hexer 1.4.*
     - laszip 3.2.*
     - curl
     - zlib
@@ -53,7 +52,6 @@ requirements:
     - {{ pin_compatible('geotiff', max_pin='x.x') }}
     - {{ pin_compatible('nitro', max_pin='x.x') }}
     - {{ pin_compatible('libkml', max_pin='x.x') }}
-    - {{ pin_compatible('hexer', max_pin='x.x') }}
     - {{ pin_compatible('laszip', max_pin='x.x') }}
     - {{ pin_compatible('pcl', max_pin='x.x') }}
     - {{ pin_compatible('hdf5', max_pin='x.x.x') }}


### PR DESCRIPTION
MNT: Re-rendered with conda-smithy 3.1.12 and pinning 2018.11.27

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
