### PR TITLE
Remove xercces-c dependency

### DIFF
--- a/.ci_support/linux_python3.6.yaml
+++ b/.ci_support/linux_python3.6.yaml
@@ -50,8 +50,6 @@ pin_run_as_build:
     max_pin: x
   tiledb:
     max_pin: x.x.x
-  xerces-c:
-    max_pin: x.x.x
   zlib:
     max_pin: x.x
   zstd:
@@ -62,8 +60,6 @@ sqlite:
 - '3'
 tiledb:
 - 1.7.0
-xerces_c:
-- 3.2.2
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/linux_python3.7.yaml
+++ b/.ci_support/linux_python3.7.yaml
@@ -50,8 +50,6 @@ pin_run_as_build:
     max_pin: x
   tiledb:
     max_pin: x.x.x
-  xerces-c:
-    max_pin: x.x.x
   zlib:
     max_pin: x.x
   zstd:
@@ -62,8 +60,6 @@ sqlite:
 - '3'
 tiledb:
 - 1.7.0
-xerces_c:
-- 3.2.2
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/linux_python3.8.yaml
+++ b/.ci_support/linux_python3.8.yaml
@@ -50,8 +50,6 @@ pin_run_as_build:
     max_pin: x
   tiledb:
     max_pin: x.x.x
-  xerces-c:
-    max_pin: x.x.x
   zlib:
     max_pin: x.x
   zstd:
@@ -62,8 +60,6 @@ sqlite:
 - '3'
 tiledb:
 - 1.7.0
-xerces_c:
-- 3.2.2
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/osx_python3.6.yaml
+++ b/.ci_support/osx_python3.6.yaml
@@ -54,8 +54,6 @@ pin_run_as_build:
     max_pin: x
   tiledb:
     max_pin: x.x.x
-  xerces-c:
-    max_pin: x.x.x
   zlib:
     max_pin: x.x
   zstd:
@@ -66,8 +64,6 @@ sqlite:
 - '3'
 tiledb:
 - 1.7.0
-xerces_c:
-- 3.2.2
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/osx_python3.7.yaml
+++ b/.ci_support/osx_python3.7.yaml
@@ -54,8 +54,6 @@ pin_run_as_build:
     max_pin: x
   tiledb:
     max_pin: x.x.x
-  xerces-c:
-    max_pin: x.x.x
   zlib:
     max_pin: x.x
   zstd:
@@ -66,8 +64,6 @@ sqlite:
 - '3'
 tiledb:
 - 1.7.0
-xerces_c:
-- 3.2.2
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/osx_python3.8.yaml
+++ b/.ci_support/osx_python3.8.yaml
@@ -54,8 +54,6 @@ pin_run_as_build:
     max_pin: x
   tiledb:
     max_pin: x.x.x
-  xerces-c:
-    max_pin: x.x.x
   zlib:
     max_pin: x.x
   zstd:
@@ -66,8 +64,6 @@ sqlite:
 - '3'
 tiledb:
 - 1.7.0
-xerces_c:
-- 3.2.2
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.6vc14.yaml
+++ b/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.6vc14.yaml
@@ -46,8 +46,6 @@ pin_run_as_build:
     max_pin: x.x.x
   vc:
     max_pin: x
-  xerces-c:
-    max_pin: x.x.x
   zlib:
     max_pin: x.x
   zstd:
@@ -60,8 +58,6 @@ tiledb:
 - 1.7.0
 vc:
 - '14'
-xerces_c:
-- 3.2.2
 zip_keys:
 - - python
   - vc

--- a/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.7vc14.yaml
+++ b/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.7vc14.yaml
@@ -46,8 +46,6 @@ pin_run_as_build:
     max_pin: x.x.x
   vc:
     max_pin: x
-  xerces-c:
-    max_pin: x.x.x
   zlib:
     max_pin: x.x
   zstd:
@@ -60,8 +58,6 @@ tiledb:
 - 1.7.0
 vc:
 - '14'
-xerces_c:
-- 3.2.2
 zip_keys:
 - - python
   - vc

--- a/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.8vc14.yaml
+++ b/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.8vc14.yaml
@@ -46,8 +46,6 @@ pin_run_as_build:
     max_pin: x.x.x
   vc:
     max_pin: x
-  xerces-c:
-    max_pin: x.x.x
   zlib:
     max_pin: x.x
   zstd:
@@ -60,8 +58,6 @@ tiledb:
 - 1.7.0
 vc:
 - '14'
-xerces_c:
-- 3.2.2
 zip_keys:
 - - python
   - vc

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ A feedstock is made up of a conda recipe (the instructions on what and how to bu
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
 [CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.org/) it is possible to build and upload installable
+and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
 packages to the [conda-forge](https://anaconda.org/conda-forge)
 [Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - e57.patch
 
 build:
-  number: 7
+  number: 8
   skip: True  # [(win and vc<14) or py<35]
 
 requirements:
@@ -40,7 +40,6 @@ requirements:
     - tiledb
     - zstd
     - libxml2
-    - xerces-c
   run:
     - python
     - numpy
@@ -59,7 +58,6 @@ requirements:
     - tiledb
     - zstd
     - libxml2
-    - xerces-c
 
 test:
   commands:


### PR DESCRIPTION
Xerces-c comes from GDAL anyway. We don't want to pin it ourselves.