### PR TITLE
Create intermediate build against libpq=13

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,7 +11,7 @@ jobs:
       linux_64_:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_aarch64_:
         CONFIG: linux_aarch64_
         UPLOAD_PACKAGES: 'True'

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '9'
 docker_image:
-- quay.io/condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 geotiff:
 - '1.7'
 hdf5:
@@ -52,8 +52,6 @@ tiledb:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - cdt_name
-  - docker_image
 zlib:
 - '1.2'
 zstd:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - unmap.patch
 
 build:
-  number: 17
+  number: 18
   skip: true  # [(win and vc<14) or py<35]
 
 requirements:
@@ -24,7 +24,7 @@ requirements:
     - pkg-config
     - libgdal
     - geotiff
-    - libpq
+    - libpq >=13,<14
     - jsoncpp
     - libkml
     - eigen
@@ -41,7 +41,7 @@ requirements:
   host:
     - libgdal
     - geotiff
-    - libpq
+    - libpq >=13,<14
     - jsoncpp
     - libkml
     - eigen
@@ -58,7 +58,7 @@ requirements:
   run:
     - libgdal
     - geotiff
-    - libpq
+    - libpq >=13,<14
     - jsoncpp
     - libkml
     - eigen


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

conda-forge currently has some dependency ugliness as a result of the `qt` feedstock being in a state of unbuildable flux.  I have some lengthy thrashing denoted at conda-forge/gdal-feedstock#585 

The long story short is that we have a very narrow dependency path that presently includes gdal=3.4.0 + libpq 13.  This creates an intermediate build of pdal against libpq=13, which would hopefully allow PRs like conda-forge/qgis-feedstock#218 to work.

If accepted, I'll submit a subsequent PR that undoes this pinning.