### PR TITLE
revert libpq pinning done for intermediate build #154

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - unmap.patch
 
 build:
-  number: 18
+  number: 19
   skip: true  # [(win and vc<14) or py<35]
 
 requirements:
@@ -24,7 +24,7 @@ requirements:
     - pkg-config
     - libgdal
     - geotiff
-    - libpq >=13,<14
+    - libpq
     - jsoncpp
     - libkml
     - eigen
@@ -41,7 +41,7 @@ requirements:
   host:
     - libgdal
     - geotiff
-    - libpq >=13,<14
+    - libpq
     - jsoncpp
     - libkml
     - eigen
@@ -58,7 +58,7 @@ requirements:
   run:
     - libgdal
     - geotiff
-    - libpq >=13,<14
+    - libpq
     - jsoncpp
     - libkml
     - eigen


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
*  Ensured the license file is being packaged.

This reverts the `libpq` pinning done for the intermediate build from #154.  Thanks for indulging me with this intermediate build in hopes of helping conda-forge/qgis-feedstock#218

@conda-forge-admin, please rerender