### PR TITLE
Rebuild for geotiff 1.7.0

### DIFF
--- a/.ci_support/linux_64_openssl1.1.1.yaml
+++ b/.ci_support/linux_64_openssl1.1.1.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 geotiff:
-- '1.7'
+- 1.7.0
 hdf5:
 - 1.12.1
 libgdal:

--- a/.ci_support/linux_64_openssl3.yaml
+++ b/.ci_support/linux_64_openssl3.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 geotiff:
-- '1.7'
+- 1.7.0
 hdf5:
 - 1.12.1
 libgdal:

--- a/.ci_support/linux_aarch64_openssl1.1.1.yaml
+++ b/.ci_support/linux_aarch64_openssl1.1.1.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
 geotiff:
-- '1.7'
+- 1.7.0
 hdf5:
 - 1.12.1
 libgdal:

--- a/.ci_support/linux_aarch64_openssl3.yaml
+++ b/.ci_support/linux_aarch64_openssl3.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
 geotiff:
-- '1.7'
+- 1.7.0
 hdf5:
 - 1.12.1
 libgdal:

--- a/.ci_support/linux_ppc64le_openssl1.1.1.yaml
+++ b/.ci_support/linux_ppc64le_openssl1.1.1.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
 geotiff:
-- '1.7'
+- 1.7.0
 hdf5:
 - 1.12.1
 libgdal:

--- a/.ci_support/linux_ppc64le_openssl3.yaml
+++ b/.ci_support/linux_ppc64le_openssl3.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
 geotiff:
-- '1.7'
+- 1.7.0
 hdf5:
 - 1.12.1
 libgdal:

--- a/.ci_support/osx_64_openssl1.1.1.yaml
+++ b/.ci_support/osx_64_openssl1.1.1.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '12'
 geotiff:
-- '1.7'
+- 1.7.0
 hdf5:
 - 1.12.1
 libgdal:

--- a/.ci_support/osx_64_openssl3.yaml
+++ b/.ci_support/osx_64_openssl3.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '12'
 geotiff:
-- '1.7'
+- 1.7.0
 hdf5:
 - 1.12.1
 libgdal:

--- a/.ci_support/osx_arm64_openssl1.1.1.yaml
+++ b/.ci_support/osx_arm64_openssl1.1.1.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '12'
 geotiff:
-- '1.7'
+- 1.7.0
 hdf5:
 - 1.12.1
 libgdal:

--- a/.ci_support/osx_arm64_openssl3.yaml
+++ b/.ci_support/osx_arm64_openssl3.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '12'
 geotiff:
-- '1.7'
+- 1.7.0
 hdf5:
 - 1.12.1
 libgdal:

--- a/.ci_support/win_64_openssl1.1.1.yaml
+++ b/.ci_support/win_64_openssl1.1.1.yaml
@@ -9,7 +9,7 @@ curl:
 cxx_compiler:
 - vs2017
 geotiff:
-- '1.7'
+- 1.7.0
 hdf5:
 - 1.12.1
 libgdal:

--- a/.ci_support/win_64_openssl3.yaml
+++ b/.ci_support/win_64_openssl3.yaml
@@ -9,7 +9,7 @@ curl:
 cxx_compiler:
 - vs2017
 geotiff:
-- '1.7'
+- 1.7.0
 hdf5:
 - 1.12.1
 libgdal:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 8dda872ae6c08973125757be8ba5591b7cf7304c58943447fc3df9c9ac2cdc42
 
 build:
-  number: 0
+  number: 1
   skip: true  # [(win and vc<14) or py<37]
   run_exports:
     - {{ pin_subpackage('pdal', max_pin='x.x') }}


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Related to #170, conda-forge-pinning was updated to pin down geotiff to 1.7.0 to prevent dependency islands and to keep the bot marching geotiff forward properly with migrations.  This PR is a simple rerender.