### PR TITLE
Rebuild for libgdal3.9 and remove pin_compatible deps

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -24,12 +24,16 @@ hdf5:
 - 1.14.3
 libcurl:
 - '8'
+libgdal:
+- '3.9'
 libkml:
 - '1.3'
 libpq:
 - '16'
 libxml2:
 - '2'
+proj:
+- 9.4.0
 target_platform:
 - linux-64
 tiledb:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -28,12 +28,16 @@ hdf5:
 - 1.14.3
 libcurl:
 - '8'
+libgdal:
+- '3.9'
 libkml:
 - '1.3'
 libpq:
 - '16'
 libxml2:
 - '2'
+proj:
+- 9.4.0
 target_platform:
 - linux-aarch64
 tiledb:

--- a/.ci_support/migrations/libgdal39.yaml
+++ b/.ci_support/migrations/libgdal39.yaml
@@ -1,0 +1,9 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+gdal:
+- '3.9'
+libgdal:
+- '3.9'
+migrator_ts: 1715443551.4913723

--- a/.ci_support/migrations/tiledb223.yaml
+++ b/.ci_support/migrations/tiledb223.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for tiledb 2.23
-  kind: version
-  migration_number: 1
-migrator_ts: 1715281095.4532387
-tiledb:
-- '2.23'

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -24,6 +24,8 @@ hdf5:
 - 1.14.3
 libcurl:
 - '8'
+libgdal:
+- '3.9'
 libkml:
 - '1.3'
 libpq:
@@ -32,6 +34,8 @@ libxml2:
 - '2'
 macos_machine:
 - x86_64-apple-darwin13.4.0
+proj:
+- 9.4.0
 target_platform:
 - osx-64
 tiledb:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -24,6 +24,8 @@ hdf5:
 - 1.14.3
 libcurl:
 - '8'
+libgdal:
+- '3.9'
 libkml:
 - '1.3'
 libpq:
@@ -32,6 +34,8 @@ libxml2:
 - '2'
 macos_machine:
 - arm64-apple-darwin20.0.0
+proj:
+- 9.4.0
 target_platform:
 - osx-arm64
 tiledb:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -14,6 +14,8 @@ hdf5:
 - 1.14.3
 libcurl:
 - '8'
+libgdal:
+- '3.9'
 libkml:
 - '1.3'
 libpq:
@@ -22,6 +24,8 @@ libxml2:
 - '2'
 mkl:
 - '2023'
+proj:
+- 9.4.0
 target_platform:
 - win-64
 tiledb:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,8 +24,8 @@ requirements:
     - pkg-config
 
   host:
-    - {{ pin_compatible('libgdal', max_pin='x.x') }}
-    - {{ pin_compatible('proj', max_pin='x.x') }}
+    - libgdal
+    - proj
     - geotiff
     - libpq
     - libkml
@@ -43,8 +43,8 @@ requirements:
     - blas  # [win]
 
   run:
-    - {{ pin_compatible('libgdal', max_pin='x.x') }}
-    - {{ pin_compatible('proj', max_pin='x.x') }}
+    - libgdal
+    - proj
     - geotiff
     - libpq
     - libkml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 7769aaacfc26daeb559b511c73c241a5e9a2f31e26ef3a736204b83e791c5453
 
 build:
-  number: 8
+  number: 9
   skip: true  # [ppc64le]
   run_exports:
     - {{ pin_subpackage('pdal', max_pin='x.x') }}


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

I don't think `pin_compatible` is right as these packages are already in conda-forge-pinning , without this change, migrations will not happen.  I am probably horribly wrong about all this, eh.

@conda-forge-admin please rerender